### PR TITLE
Pass moment to the function

### DIFF
--- a/src/pat-display-time.js
+++ b/src/pat-display-time.js
@@ -10,7 +10,7 @@
         } else {
             factory(root.patterns, root.patterns.Parser);
         }
-}(this, function(registry, Parser) {
+}(this, function(registry, Parser, moment) {
     'use strict';
 
     var parser = new Parser('display-time');


### PR DESCRIPTION
I don't know why this only breaks now, but without having moment in the function arguments, it isn't found in the body.
