### PR TITLE
Use moment.locale because moment.lang is deprecated

### DIFF
--- a/src/pat-display-time.js
+++ b/src/pat-display-time.js
@@ -26,9 +26,9 @@
 
     var lang = document.getElementsByTagName("html")[0].getAttribute("lang");
     if (lang === "de") {
-        moment.lang("de");
+        moment.locale("de");
     } else {
-        moment.lang("en");
+        moment.locale("en");
     }
 
     var parser = new Parser("display-time");


### PR DESCRIPTION
moment.lang is deprecated since version 2.8.1:

- http://momentjs.com/docs/#/i18n/changing-locale/

We are using moment 2.13.0 today:

- https://github.com/quaive/ploneintranet.prototype/blob/master/bower.json#L22